### PR TITLE
add support for PodScheduled = False

### DIFF
--- a/wait_for.sh
+++ b/wait_for.sh
@@ -49,6 +49,9 @@ get_pod_state() {
 {{- define "checkStatus" -}}
   {{- $rootStatus := .status }}
   {{- range .status.conditions -}}
+      {{- if and (eq .type "PodScheduled") (eq .status "False") -}}
+        {{ .status }}
+      {{- end -}}
       {{- if and (eq .type "Ready") (eq .status "False") -}}
       {{- if .reason -}}
         {{- if ne .reason "PodCompleted" -}}


### PR DESCRIPTION
When the Status is Pending the output does not contain the "Ready" type status at all. The script will just "fall through" and a pod that has PodScheduled = False is considered as ready when it is not.