### PR TITLE
Allow failed jobs on success

### DIFF
--- a/wait_for.sh
+++ b/wait_for.sh
@@ -147,7 +147,7 @@ get_job_state() {
     
     # Map triplets of <running>:<succeeded>:<failed> to not ready (emit 0) state
     if [ $TREAT_ERRORS_AS_READY -eq 0 ]; then
-        sed_reg='-e s/^[1-9]+:[[:digit:]]+:[[:digit:]]+$/1/p -e s/^0:[[:digit:]]+:[1-9]+$/1/p'
+        sed_reg='-e s/^[1-9]+:[[:digit:]]+:[[:digit:]]+$/1/p -e s/^0:0:[1-9]+$/1/p'
     else
         sed_reg='-e s/^[1-9]+:[[:digit:]]+:[[:digit:]]+$/1/p'
     fi


### PR DESCRIPTION
Waiting for job is left into waiting state indefinitely if there is a failed job in addition to the successful one. This happens as the regex matching for failed jobs does not check for successful runs.

In the error case `$get_job_state_output1` contains "0:1:1". I assume this should be treated as success as there is a successful job run without any active jobs running.