### PR TITLE
Handle missing pod condition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.docker.dockerfile="/Dockerfile"
 
-ENV KUBE_LATEST_VERSION="v1.11.0"
+ENV KUBE_LATEST_VERSION="v1.14.1"
 
 RUN apk add --update ca-certificates curl jq \
  && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \


### PR DESCRIPTION
If a pod does not report its `Ready` condition, `k8s-wait-for` will think it is ready.
This problem occurs very frequently when waiting for [elasticsearch](https://github.com/elastic/helm-charts/tree/master/elasticsearch).

A similar issue was already discussed in https://github.com/groundnuty/k8s-wait-for/pull/10 and this PR offers a more general solution that doesn't rely on the `PodScheduled` value.
Had to upgrade kubectl version because modified script doesn't work with the older one.