### PR TITLE
Fix not found jobs are ready

### DIFF
--- a/wait_for.sh
+++ b/wait_for.sh
@@ -145,7 +145,7 @@ get_job_state() {
     elif [ $DEBUG -ge 2 ]; then
         echo "$get_job_state_output" >&2
     fi
-    if [ "$get_job_state_output" = "" ]; then
+    if [[ "$get_job_state_output" = "" || "$get_job_state_output" == *"No resources found"* ]]; then
         echo "wait_for.sh: No jobs found!" >&2
         kill -s TERM $TOP_PID
     fi

--- a/wait_for.sh
+++ b/wait_for.sh
@@ -145,7 +145,7 @@ get_job_state() {
     elif [ $DEBUG -ge 2 ]; then
         echo "$get_job_state_output" >&2
     fi
-    if [[ "$get_job_state_output" = "" || "$get_job_state_output" == *"No resources found"* ]]; then
+    if [[ "$get_job_state_output" == "" || "$get_job_state_output" == *"No resources found"* ]]; then
         echo "wait_for.sh: No jobs found!" >&2
         kill -s TERM $TOP_PID
     fi


### PR DESCRIPTION
### Problem
I am using job selector with labels. If selector not found, `wait-for` treat it as ready (But it doesn't exists!). I found check and fixed this case i guess


### Additional info
Debug logs
![image](https://user-images.githubusercontent.com/46970457/103208781-91d7a580-4912-11eb-8b30-eb149658bf87.png)
No resources found is `get_job_state_output` output, but script tries to extract job status from it

Selector:
```yaml
args: [job, "-l app.kubernetes.io/name in (migrations), app.kubernetes.io/version in (0.0.244)"]
env:
  - name: DEBUG
    value: "3"
```