### PR TITLE
Allow failing pod during waiting for successful one

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ wait_for.sh job develop-volume-s3-krakow-init
 Wait for all the pods in that job to have a 'Succeeded' or 'Failed' state:
 wait_for.sh job-we develop-volume-s3-krakow-init
 
-Wait for at least one pod in that job to have 'Succeeded' state, pods with 'Failed' state does not matter:
+Wait for at least one pod in that job to have 'Succeeded' state, does not mind some 'Failed' ones:
 ${0##*/} job-wr develop-volume-s3-krakow-init
 
 Wait for all selected pods to enter the 'Ready' state:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ wait_for.sh job develop-volume-s3-krakow-init
 Wait for all the pods in that job to have a 'Succeeded' or 'Failed' state:
 wait_for.sh job-we develop-volume-s3-krakow-init
 
+Wait for at least one pod in that job to have 'Succeeded' state, pods with 'Failed' state does not matter:
+${0##*/} job-wr develop-volume-s3-krakow-init
+
 Wait for all selected pods to enter the 'Ready' state:
 wait_for.sh pod -l"release in (develop), chart notin (cross-support-job-3p)"
 ```

--- a/wait_for.sh
+++ b/wait_for.sh
@@ -169,7 +169,7 @@ get_job_state() {
         # Two conditions: 
         #   - pods are distributed between all 3 states with at least 1 pod running - then emit 1
         #   - or more then 1 pod have failed and some are completed - also emit 1
-        sed_reg='-e s/^[1-9][[:digit:]]*:[[:digit:]]+:[[:digit:]]+$/1/p -e s/^0:[[:digit:]]+:[1-9][[:digit:]]+$/1/p'
+        sed_reg='-e s/^[1-9][[:digit:]]*:[[:digit:]]+:[[:digit:]]+$/1/p -e s/^0:[[:digit:]]+:[1-9][[:digit:]]*$/1/p'
     else
         # When allowing for failed jobs
         #   - pods are distributed between all 3 states with at least 1 pod running- then emit 1

--- a/wait_for.sh
+++ b/wait_for.sh
@@ -33,7 +33,7 @@ ${0##*/} job develop-volume-s3-krakow-init
 Wait for all the pods in that job to have a 'Succeeded' or 'Failed' state:
 ${0##*/} job-we develop-volume-s3-krakow-init
 
-Wait for at least one pod in that job to have 'Succeeded' state, pods with 'Failed' state does not matter:
+Wait for at least one pod in that job to have 'Succeeded' state, does not mind some 'Failed' ones:
 ${0##*/} job-wr develop-volume-s3-krakow-init
 
 Wait for all selected pods to enter the 'Ready' state:


### PR DESCRIPTION
For current solution, when waiting for job, there is no option to wait for successful job with allowing some pods to fail during process. In our case, sometimes our job fails on transient error and succeeds in next try. The result is 0:1:1 which is handled as failed (with "job" param). When I use "job-we", there is a possibility to handle state 0:0:5 as a successful one, which is not the desired scenario.

I've introduced "job-wr" param, which will wait for at least one successful pod but doesnt mind some failed ones.