### PR TITLE
Fix get_job_state_output substring matching

### DIFF
--- a/wait_for.sh
+++ b/wait_for.sh
@@ -145,7 +145,7 @@ get_job_state() {
     elif [ $DEBUG -ge 2 ]; then
         echo "$get_job_state_output" >&2
     fi
-    if [[ "$get_job_state_output" == "" || "$get_job_state_output" == *"No resources found"* ]]; then
+    if [ "$get_job_state_output" == "" ] || echo "$get_job_state_output" | grep -q "No resources found"; then
         echo "wait_for.sh: No jobs found!" >&2
         kill -s TERM $TOP_PID
     fi


### PR DESCRIPTION
Previous PR #24 did not solve the issue.
Bourne shell is not supporting conditions using double brackets `[[ ]]` nor the syntax `string == *"subString"*`
