### PR TITLE
Add mention about potential error case

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,6 @@ or use these command lines which add services and deployments to the pods in tho
 `kubectl create rolebinding default-pod-reader --role=pod-reader --serviceaccount=default:default --namespace=default`
 
 An extensive discussion on the problem of granting necessary permisions and a number of example solutions can be found [here](https://github.com/groundnuty/k8s-wait-for/issues/6).
+
+Make sure the service account is mounted. `The connection to the server localhost:8080 was refused - did you specify the right host or port?` might indicate that the service account is not mounted to the pod. Double check wether your service account and pod define `automountServiceAccountToken: true`. If the service account is mounted, you should see files inside `/var/run/secrets/kubernetes.io/serviceaccount` folder, otherwise `/var/run/secrets/kubernetes.io` might not exist at all.
+


### PR DESCRIPTION
Sometimes service account might not get mounted by default. e.g here the `automount_service_account_token` defaults to `false`: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/modules/workload-identity#inputs