### PR TITLE
Add timestamp to "Waiting for ..." outputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 
 ENV KUBE_LATEST_VERSION="v1.21.0"
 
-RUN apk add --update --no-cache ca-certificates=20191127-r4 curl=7.78.0-r0 jq=1.6-r1 \
+RUN apk add --update --no-cache ca-certificates=20191127-r4 curl=7.79.1-r0 jq=1.6-r1 \
  && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
  && chmod +x /usr/local/bin/kubectl
 

--- a/wait_for.sh
+++ b/wait_for.sh
@@ -14,7 +14,7 @@ TREAT_ERRORS_AS_READY=0
 
 usage() {
 cat <<EOF
-This script waits until a job, pod or service enter ready state. 
+This script waits until a job, pod or service enter ready state.
 
 ${0##*/} job [<job name> | -l<kubectl selector>]
 ${0##*/} pod [<pod name> | -l<kubectl selector>]
@@ -166,10 +166,10 @@ get_job_state() {
     if [ $DEBUG -ge 1 ]; then
         echo "$get_job_state_output1" >&2
     fi
-    
+
     # Map triplets of <running>:<succeeded>:<failed> to not ready (emit 1) state
     if [ $TREAT_ERRORS_AS_READY -eq 0 ]; then
-        # Two conditions: 
+        # Two conditions:
         #   - pods are distributed between all 3 states with at least 1 pod running - then emit 1
         #   - or more then 1 pod have failed and some are completed - also emit 1
         sed_reg='-e s/^[1-9][[:digit:]]*:[[:digit:]]+:[[:digit:]]+$/1/p -e s/^0:[[:digit:]]+:[1-9][[:digit:]]*$/1/p'
@@ -185,7 +185,7 @@ get_job_state() {
         #   - when no pod is running and at least one is completed - all is fine
         sed_reg='-e s/^[1-9][[:digit:]]*:[[:digit:]]+:[[:digit:]]+$/1/p -e s/^0:0:[[:digit:]]+$/1/p'
     fi
-    
+
     get_job_state_output2=$(printf "%s" "$get_job_state_output1" | sed -nr $sed_reg 2>&1)
     if [ $DEBUG -ge 1 ]; then
         echo "$get_job_state_output2" >&2

--- a/wait_for.sh
+++ b/wait_for.sh
@@ -204,7 +204,8 @@ wait_for_resource() {
     while [ -n "$(get_${wait_for_resource_type}_state "$wait_for_resource_descriptor")" ] ; do
         print_KUBECTL_ARGS="$KUBECTL_ARGS"
         [ "$print_KUBECTL_ARGS" != "" ] && print_KUBECTL_ARGS=" $print_KUBECTL_ARGS"
-        echo "Waiting for $wait_for_resource_type $wait_for_resource_descriptor${print_KUBECTL_ARGS}..."
+        timestamp=$(date +'%Y-%m-%d %H:%M:%S')
+        echo "[$timestamp] Waiting for $wait_for_resource_type $wait_for_resource_descriptor${print_KUBECTL_ARGS}..."
         sleep "$WAIT_TIME"
     done
     ready "$wait_for_resource_type" "$wait_for_resource_descriptor"


### PR DESCRIPTION
This PR closes https://github.com/groundnuty/k8s-wait-for/issues/35 by adding timestamps to the recurring "Waiting for ..." log statements.

This PR also removes trailing whitespaces and bumps the explicit curl version in `Dockerfile` to make builds work again.

@groundnuty would you mind tagging your repo (or this specific PR) as hacktoberfest accepted? 