### PR TITLE
Encourage the use of the ghcr repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A simple script that allows waiting for a k8s service, job or pods to enter the 
 You can start simple. Run it on your cluster in a namespace you already have something deployed:
 
 ```bash
-kubectl run k8s-wait-for --rm -it --image groundnuty/k8s-wait-for:v1.3 --restart Never --command /bin/sh
+kubectl run k8s-wait-for --rm -it --image ghcr.io/groundnuty/k8s-wait-for:v1.6 --restart Never --command /bin/sh
 ```
 
 Read `--help` and play with it!
@@ -86,19 +86,19 @@ spec:
     spec:
       initContainers:
         - name: wait-for-onezone
-          image: groundnuty/k8s-wait-for:v1.3
+          image: ghcr.io/groundnuty/k8s-wait-for:v1.6
           imagePullPolicy: Always
           args:
             - "job"
             - "develop-onezone-ready-check"
         - name: wait-for-volume-ceph
-          image: groundnuty/k8s-wait-for:v1.3
+          image: ghcr.io/groundnuty/k8s-wait-for:v1.6
           imagePullPolicy: Always
           args:
             - "pod"
             - "-lapp=develop-volume-ceph-krakow"
         - name: wait-for-volume-gluster
-          image: groundnuty/k8s-wait-for:v1.3
+          image: ghcr.io/groundnuty/k8s-wait-for:v1.6
           imagePullPolicy: Always
           args:
             - "pod"


### PR DESCRIPTION
Due to Docker's harsh pull limits, encourage users to use gh.cr by modifying the readme accordingly.

Also bump to the latest tagged release version.