### PR TITLE
Re-add support for Kubernetes versions <= v1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > This tool is still actively used and working stably despite not too frequent commits! Pull requests are most welcome!
 
-> Important: For kubernetes versions <=1.23 use k8s-wait-for versions 1.*, see [here](https://github.com/groundnuty/k8s-wait-for/issues/60#issuecomment-1313483011).
+> Important: For kubernetes versions <=1.23, use k8s-wait-for version 2.1 or higher or k8s-wait-for versions 1.*. See [here](https://github.com/groundnuty/k8s-wait-for/issues/60#issuecomment-1313483011).
 
 A simple script that allows waiting for a k8s service, job or pods to enter the desired state.
 

--- a/wait_for.sh
+++ b/wait_for.sh
@@ -174,9 +174,9 @@ get_job_state() {
         kill -s TERM $TOP_PID
     fi
 
-    # Extract number of <avtive>:<ready>:<succeeded>:<failed>
-    # Ignore the Ready number, as it will alwasy be less or equal to Active number
-    get_job_state_output1=$(printf "%s" "$get_job_state_output" | sed -nr 's#.*:[[:blank:]]+([[:digit:]]+) [[:alpha:]]+ \(+([[:digit:]]+) [[:alpha:]]+\) / ([[:digit:]]+) [[:alpha:]]+ / ([[:digit:]]+) [[:alpha:]]+.*#\1:\3:\4#p' 2>&1)
+    # Extract number of <active>:<succeeded>:<failed>
+    # Ignore the Ready number if it exists, as it will always be less or equal to Active number
+    get_job_state_output1=$(printf "%s" "$get_job_state_output" | sed -nr 's#.*:[[:blank:]]+([[:digit:]]+) [[:alpha:]]+ (\(+[[:digit:]]+ [[:alpha:]]+\) )?/ ([[:digit:]]+) [[:alpha:]]+ / ([[:digit:]]+) [[:alpha:]]+.*#\1:\3:\4#p' 2>&1)
     if [ $? -ne 0 ]; then
         echo "$get_job_state_output" >&2
         echo "$get_job_state_output1" >&2
@@ -185,7 +185,7 @@ get_job_state() {
         echo "${get_job_state_output1}" >&2
     fi
 
-    # Map triplets of <avtive>:<succeeded>:<failed> to not ready (emit 1) state
+    # Map triplets of <active>:<succeeded>:<failed> to not ready (emit 1) state
     if [ $TREAT_ERRORS_AS_READY -eq 0 ]; then
         # Two conditions:
         #   - pods are distributed between all 3 states with at least 1 pod active - then emit 1


### PR DESCRIPTION
In k8s-wait-for version 2.0, support was dropped for Kubernetes versions 1.23 and earlier. (See https://github.com/groundnuty/k8s-wait-for/releases/tag/v2.0 and https://github.com/groundnuty/k8s-wait-for/issues/60)

After reviewing the code, it would be simple to continue to support earlier versions. Because we do not care about the Ready value, we do not need to explicitly capture the digit; instead, we can capture the whole `(0 Ready) ` string zero or one times. We then ignore the captured value, as we do today.

I do appreciate the desire to push people to the latest releases of Kubernetes, but in this case, I believe the extra code required is minimal. It also this simplifies our ability to use the project when we cannot reliably know what k8s version is being used, and prevents people from being locked on k8s-wait-for 1.x.

Changes:
* Updated the regular expression used by sed, to capture the full Ready statement
* Updated README to account for this change, as consumers would no longer need to use k8s-wait-for 1.x
* Fixed comment typos