### PR TITLE
Reduce number of CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2
+FROM alpine:3.17.2
 
 MAINTAINER Michal Orzechowski <orzechowski.michal@gmail.com>
 
@@ -12,11 +12,13 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.docker.dockerfile="/Dockerfile"
 
-ENV KUBE_LATEST_VERSION="v1.25.4"
+ENV KUBE_LATEST_VERSION="v1.26.3"
 
-RUN apk add --update --no-cache ca-certificates=20220614-r0 curl=7.83.1-r4 jq=1.6-r1 \
+RUN apk add --update --no-cache ca-certificates=20220614-r4 curl=7.88.1-r1 jq=1.6-r2 \
     && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/$TARGETARCH/kubectl -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
+
+RUN apk update && apk add "libcrypto3>=3.0.8-r1" "libssl3>=3.0.8-r1" && rm -rf /var/cache/apt/*
 
 # Replace for non-root version
 ADD wait_for.sh /usr/local/bin/wait_for.sh


### PR DESCRIPTION
This PR should remove a part of the CVEs being flagged when this image is scanned. Please see the following screenshot for more information on CVE flagged as of today:
![image](https://user-images.githubusercontent.com/10722526/228599714-ee1ddea9-746e-4e86-ad31-b09c364de2d5.png)

I have updated the following dependencies:
- Updated CURL JQ and CA
- Updated Kubernetes CLI
- Updated libcrypto3
- Updated libssl3
- Updated base alpine image
