### PR TITLE
Use `/tmp` as $HOME for the 1100 user in the rootless image

### DIFF
--- a/DockerfileNonRoot.snipset
+++ b/DockerfileNonRoot.snipset
@@ -6,7 +6,7 @@ RUN addgroup -g $GID $USER && \
     adduser \
     --disabled-password \
     --gecos "" \
-    --home "$(pwd)" \
+    --home "/tmp" \
     --ingroup "$USER" \
     --no-create-home \
     --uid "$UID" \


### PR DESCRIPTION
`kubectl` needs a place to cache files. Currently, the home for that user is `/`, which is not writable. Change it to `/tmp` to fix the issue.

Fixes https://github.com/groundnuty/k8s-wait-for/issues/32